### PR TITLE
Correctly generate codes for odd secrets

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,7 +50,7 @@ function base32tohex(base32) {
         var chunk = bits.substr(i, 4);
         hex = hex + parseInt(chunk, 2).toString(16) ;
     }
-    return hex;
+    return hex.length % 2 ? hex + "0" : hex;
 };
 
 


### PR DESCRIPTION
Fix secrets with byte increments

This was also fixed in other libraries that used the same `base32tohex` function like https://github.com/nextcloud/passman/pull/649

The bug is quickly summarized in https://github.com/nextcloud/passman/issues/293#issuecomment-362905855

## Expected behavior
1. Use the following secret `NN5VK226JVKVE3ZKJFEFESB7FR3CYRBSOESUELRGINVTM42SKZYA`
2. Get TOTP codes

## Actual behavior 
1. Use the following secret `NN5VK226JVKVE3ZKJFEFESB7FR3CYRBSOESUELRGINVTM42SKZYA`
2. Notice the `Invalid key` error and the `String of HEX type must be in byte increments` error of jsSHA library
